### PR TITLE
More cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+; EditorConfig is awesome: http://EditorConfig.org
+
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+; 2 space indentation
+[*.js]
+indent_style = space
+indent_size = 2

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,9 @@
+{
+  browser: true,
+  devel: true,
+  eqeqeq: false,
+  jquery: true,
+  smarttabs: true,
+  undef: true,
+  unused: false
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,9 +1,9 @@
 {
-  browser: true,
-  devel: true,
-  eqeqeq: false,
-  jquery: true,
-  smarttabs: true,
-  undef: true,
-  unused: false
+  "browser": true,
+  "devel": true,
+  "eqeqeq": false,
+  "jquery": true,
+  "smarttabs": true,
+  "undef": true,
+  "unused": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+### 1.0.3
+
+* Fixed facet filter removal, so facets can be removed without values
+
+### 1.0.2
+
+* Enabled single filter mode
+
+### 1.0.0
+
+* Initial release

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,13 +19,7 @@ module.exports = function (grunt) {
 		},
     jshint: {
       options: {
-        browser: true,
-        devel: true,
-        eqeqeq: false,
-        jquery: true,
-        smarttabs: true,
-        undef: true,
-        unused: false
+        jshintrc: '.jshintrc'
       },
       files: ['Gruntfile.js', '<%= pkg.scripts.main %>']
     },

--- a/README.md
+++ b/README.md
@@ -51,16 +51,3 @@ The facet filter object can be accessed by the data attribute, for example, usin
       'type': 'html' // Specify the data type returned
     }
 
-## Version History
-
-### 1.0.3
-
-* Fixed facet filter removal, so facets can be removed without values
-
-### 1.0.2
-
-* Enabled single filter mode
-
-### 1.0.0
-
-* Initial release


### PR DESCRIPTION
Couple more (hopefully) useful additions.
- Added .editorconfig. Provides a way of defining common editor/whitespace settings for files in a project, avoids messy tab/space/trailing-whitespace issues. Good idea to install and editorconfig plugin, e..g https://github.com/sindresorhus/editorconfig-sublime
- Moved history out into more standard CHANGELOG.md
- Moved jshint settings into .jshintrc, makes it easier to run directly
